### PR TITLE
Add color trait to ray sources to make controllable

### DIFF
--- a/raypier/gausslet_sources.py
+++ b/raypier/gausslet_sources.py
@@ -5,6 +5,8 @@ import time
 from traits.api import Instance, Title, Float, Tuple, Complex, Property, cached_property, \
         observe, Bool, Range, Int
 from traitsui.api import View, Item, VGroup, Tabbed, Include, Group
+from traitsui.editors.api import TupleEditor
+
 from tvtk.api import tvtk
 
 from raypier.sources import BaseRaySource, UnitTupleVector, UnitVectorTrait, sequence_grp
@@ -46,6 +48,7 @@ class BaseGaussletSource(BaseRaySource):
                        Item('scale_factor'),
                        Item('export_pipes',label="export as pipes"),
                        Item('opacity', editor=NumEditor),
+                       Item('color', editor=TupleEditor(labels=['R','G','B'])),
                        label="Display")
     
     params_grp = VGroup(
@@ -82,7 +85,12 @@ class BaseGaussletSource(BaseRaySource):
         self.vtkproperty.opacity = self.opacity
         self.para_property.opacity = self.opacity
         self.render = True
-        
+    
+    def _color_changed(self):
+        self.vtkproperty.color = self.color
+        self.para_property.color = self.color
+        self.render = True
+
     def _get_actors(self):
         actors = [self.ray_actor, self.para_ray_actor, self.start_actor, self.normals_actor]
         return actors

--- a/raypier/sources.py
+++ b/raypier/sources.py
@@ -27,7 +27,7 @@ from traits.api import HasTraits, Int, Float, \
 
 from traitsui.api import View, Item, Tabbed, VGroup, Include, \
     Group, HGroup
-from traitsui.editors.api import ButtonEditor
+from traitsui.editors.api import ButtonEditor, TupleEditor
 
 from tvtk.api import tvtk
 
@@ -88,6 +88,7 @@ class BaseRaySource(BaseBase):
     show_direction = Bool(False)
     show_normals = Bool(False)
     opacity = Range(0.0,1.0,1.0)
+    color = Tuple(Range(0.0,1.0,1.0),Range(0.0,1.0,1.0),Range(0.0,1.0,1.0))
     
     ### A dict which maps each RayCollection instance in the traced_rays
     ### list to a list/array of bools of the same length as the RayCollection
@@ -122,6 +123,7 @@ class BaseRaySource(BaseBase):
                        Item('scale_factor'),
                        Item('export_pipes',label="export as pipes"),
                        Item('opacity', editor=NumEditor),
+                       Item('color', editor=TupleEditor(labels=['R','G','B'])),
                        label="Display")
     
     traits_view = View(Item('name', show_label=False),
@@ -279,6 +281,10 @@ class BaseRaySource(BaseBase):
         
     def _opacity_changed(self):
         self.vtkproperty.opacity = self.opacity
+        self.render = True
+
+    def _color_changed(self):
+        self.vtkproperty.color = self.color
         self.render = True
     
     def _get_actors(self):


### PR DESCRIPTION
First off, I'd just like to say I've been playing around with Raypier briefly and have been absolutely blown away by the quality of it especially terms of being an interactive playground and supprting a responsive GUI for sanity testing! 

I'm aiming to use it for astronomical purposes and so tracing lots of very slightly offset plane wavefronts bouncing around. With the default settings inside the tube can get quite hectic in terms of trying to follow paths when everything is the same colour. I saw opacity was already configurable so I followed that lead to add colour as well.

Example:
![image](https://user-images.githubusercontent.com/5210224/189466472-2130b645-6d28-44a1-88e8-0e55542c4f28.png)

(Also whilst I'm not an optics expert, I'd be happy to help out where I can with this project)